### PR TITLE
Generate CLI reference docs automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -959,6 +959,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-markdown"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ebc67e6266e14f8b31541c2f204724fa2ac7ad5c17d6f5908fbb92a60f42cff"
+dependencies = [
+ "clap 4.5.37",
+]
+
+[[package]]
 name = "clap_builder"
 version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2298,6 +2307,7 @@ dependencies = [
  "bon",
  "chrono",
  "clap 4.5.37",
+ "clap-markdown",
  "console",
  "derive-getters",
  "dialoguer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,12 @@ name = "multi"
 path = "src/bin/main.rs"
 edition = "2024"
 
+[[bin]]
+name = "mkdown-docs"
+path = "src/bin/markdown.rs"
+edition = "2024"
+required-features = ["markdown"]
+
 [dependencies]
 async-stream = "0.3.6"
 async-trait = "0.1.81"
@@ -25,6 +31,7 @@ bigdecimal = { version = "0.4.7", features = ["serde-json"] }
 bon = "3.3.2"
 chrono = "0.4.38"
 clap = { version = "4.3", features = ["derive", "env"] }
+clap-markdown = { version = "0.1.4", optional = true }
 console = "0.15.8"
 derive-getters = "0.5.0"
 dialoguer = "0.11.0"
@@ -64,6 +71,7 @@ static_assertions = "1.1.0"
 
 [features]
 proxy = ["dep:pingora"]
+markdown = ["dep:clap-markdown"] # Generate markdown docs for the CLI
 
 # The profile that 'dist' will build with
 [profile.dist]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -5,7 +5,12 @@ default_to_workspace = false
 CARGO_MAKE_CLIPPY_ARGS = "-- --no-deps"
 CARGO_MAKE_COVERAGE_PROVIDER = "llvm-cov"
 CARGO_MAKE_CARGO_BUILD_TEST_FLAGS = ""
-
+# This is the directory where we generate the CLI's reference
+# documentation.
+CLI_REFERENCE_DIR = "target/debug/"
+# This is the name of the file containing the CLI's reference
+# documentation.
+CLI_REFERENCE_FILE_NAME = "reference.md"
 
 [tasks.dev-test-flow]
 dependencies = [
@@ -97,6 +102,15 @@ description = "Sort Cargo.toml"
 category = "Development"
 command = "cargo"
 args = ["sort"]
+
+[tasks.gen-cli-reference]
+description = "Generate the CLI's reference documentation in Markdown format"
+category = "Development"
+script_runner = "@shell"
+script = '''
+  mkdir -p $CLI_REFERENCE_DIR || true
+  cargo run --bin mkdown-docs --features=markdown > $CLI_REFERENCE_DIR/$CLI_REFERENCE_FILE_NAME
+'''
 
 [tasks.bacon]
 description = "Watch tests and rerun on file change."

--- a/src/bin/markdown.rs
+++ b/src/bin/markdown.rs
@@ -1,0 +1,9 @@
+use clap::{CommandFactory, Parser};
+use multitool::{Cli, Terminal};
+
+fn main() {
+    // Parse the args provided to this process, including
+    // commands and flags.
+    let markdown: String = clap_markdown::help_markdown::<Cli>();
+    println!("{markdown}");
+}


### PR DESCRIPTION
This commit adds a new executable meant for development
that generates reference documentation for the CLI
in Markdown.

In the future, we'll store the generated docs as an
artifact in CI, and then automatically push it to our
documentation site if we detect a change. For now, we'll
have to manually update the docs when we cut a release.