### PR TITLE
Introduce multi-core library.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
  "zerocopy 0.7.35",
@@ -204,9 +204,9 @@ checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-config"
-version = "1.6.1"
+version = "1.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c39646d1a6b51240a1a23bb57ea4eebede7e16fbc237fdc876980233dcecb4f"
+checksum = "b6fcc63c9860579e4cb396239570e979376e70aab79e496621748a09913f8b36"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -234,9 +234,9 @@ dependencies = [
 
 [[package]]
 name = "aws-credential-types"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4471bef4c22a06d2c7a1b6492493d3fdf24a805323109d6874f9c94d5906ac14"
+checksum = "687bc16bc431a8533fe0097c7f0182874767f920989d7260950172ae8e3c4465"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-runtime-api",
@@ -256,9 +256,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.28.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ddeb19ee86cb16ecfc871e5b0660aff6285760957aaedda6284cf0e790d3769"
+checksum = "bfa9b6986f250236c27e5a204062434a773a13243d2ffc2955f37bdba4c5c6a1"
 dependencies = [
  "bindgen",
  "cc",
@@ -269,9 +269,9 @@ dependencies = [
 
 [[package]]
 name = "aws-runtime"
-version = "1.5.6"
+version = "1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aff45ffe35196e593ea3b9dd65b320e51e2dda95aff4390bc459e461d09c6ad"
+checksum = "6c4063282c69991e57faab9e5cb21ae557e59f5b0fb285c196335243df8dc25c"
 dependencies = [
  "aws-credential-types",
  "aws-sigv4",
@@ -286,7 +286,6 @@ dependencies = [
  "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "tracing",
@@ -295,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-apigateway"
-version = "1.66.0"
+version = "1.67.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b0029b46efd45f732dc9c46f4a7bf1db83f13d72026c51c4200a8d7a2197a20"
+checksum = "17b5c19edc82a06a6b448b08ad126a3bb96dde825a30defad06070b177b978b4"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -319,9 +318,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-cloudwatch"
-version = "1.70.0"
+version = "1.71.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84865623b1276624879f5283029fa13d7e6bfd5d58eb7df4dabd485a2f291b9b"
+checksum = "8efe57205cfa2c02cd5aa0b71ecf4ae8b63a5446c79f061dc6b44e42e4cc0e75"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -346,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-lambda"
-version = "1.75.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebfb3c1189b7a906cc3e2609fc60c4e94a951f0dff53e1694e8b66c84f6b61a"
+checksum = "84a08ae86f07140925b6ff2116b8f3f5ff52a3a7d3baec15a176c0559b2ea47c"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -370,9 +369,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.64.0"
+version = "1.65.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02d4bdb0e5f80f0689e61c77ab678b2b9304af329616af38aef5b6b967b8e736"
+checksum = "8efec445fb78df585327094fcef4cad895b154b58711e504db7a93c41aa27151"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -393,9 +392,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.65.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbbb3ce8da257aedbccdcb1aadafbbb6a5fe9adf445db0e1ea897bdc7e22d08"
+checksum = "5e49cca619c10e7b002dc8e66928ceed66ab7f56c1a3be86c5437bf2d8d89bba"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -416,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.65.0"
+version = "1.66.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96a78a8f50a1630db757b60f679c8226a8a70ee2ab5f5e6e51dc67f6c61c7cfd"
+checksum = "7420479eac0a53f776cc8f0d493841ffe58ad9d9783f3947be7265784471b47a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -440,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sigv4"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d03c3c05ff80d54ff860fe38c726f6f494c639ae975203a101335f223386db"
+checksum = "3503af839bd8751d0bdc5a46b9cac93a003a353e635b0c12cf2376b5b53e41ea"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-eventstream",
@@ -455,7 +454,6 @@ dependencies = [
  "hmac",
  "http 0.2.12",
  "http 1.3.1",
- "once_cell",
  "percent-encoding",
  "sha2",
  "time",
@@ -503,9 +501,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-http"
-version = "0.62.0"
+version = "0.62.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5949124d11e538ca21142d1fba61ab0a2a2c1bc3ed323cdb3e4b878bfb83166"
+checksum = "99335bec6cdc50a346fda1437f9fefe33abf8c99060739a546a16457f2862ca9"
 dependencies = [
  "aws-smithy-eventstream",
  "aws-smithy-runtime-api",
@@ -516,7 +514,6 @@ dependencies = [
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "pin-utils",
@@ -562,12 +559,11 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-observability"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445d065e76bc1ef54963db400319f1dd3ebb3e0a74af20f7f7630625b0cc7cc0"
+checksum = "9364d5989ac4dd918e5cc4c4bdcc61c9be17dcd2586ea7f69e348fc7c6cab393"
 dependencies = [
  "aws-smithy-runtime-api",
- "once_cell",
 ]
 
 [[package]]
@@ -582,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime"
-version = "1.8.1"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0152749e17ce4d1b47c7747bdfec09dac1ccafdcbc741ebf9daa2a373356730f"
+checksum = "14302f06d1d5b7d333fd819943075b13d27c7700b414f574c3c35859bfb55d5e"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-http",
@@ -598,7 +594,6 @@ dependencies = [
  "http 1.3.1",
  "http-body 0.4.6",
  "http-body 1.0.1",
- "once_cell",
  "pin-project-lite",
  "pin-utils",
  "tokio",
@@ -607,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-runtime-api"
-version = "1.7.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3da37cf5d57011cb1753456518ec76e31691f1f474b73934a284eb2a1c76510f"
+checksum = "a1e5d9e3a80a18afa109391fb5ad09c3daf887b516c6fd805a157c6ea7994a57"
 dependencies = [
  "aws-smithy-async",
  "aws-smithy-types",
@@ -624,9 +619,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-types"
-version = "1.3.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "836155caafba616c0ff9b07944324785de2ab016141c3550bd1c07882f8cee8f"
+checksum = "40076bd09fadbc12d5e026ae080d0930defa606856186e31d83ccc6a255eeaf3"
 dependencies = [
  "base64-simd",
  "bytes",
@@ -659,9 +654,9 @@ dependencies = [
 
 [[package]]
 name = "aws-types"
-version = "1.3.6"
+version = "1.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3873f8deed8927ce8d04487630dc9ff73193bab64742a61d050e57a68dec4125"
+checksum = "8a322fec39e4df22777ed3ad8ea868ac2f94cd15e1a55f6ee8d8d6305057689a"
 dependencies = [
  "aws-credential-types",
  "aws-smithy-async",
@@ -787,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.6.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94054366e2ff97b455acdd4fdb03913f717febc57b7bbd1741b2c3b87efae030"
+checksum = "ced38439e7a86a4761f7f7d5ded5ff009135939ecb464a24452eaa4c1696af7d"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -797,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.6.1"
+version = "3.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "542a990e676ce0a0a895ae54b2d94afd012434f2228a85b186c6bc1a7056cdc6"
+checksum = "0ce61d2d3844c6b8d31b2353d9f66cf5e632b3e9549583fe3cac2f4f6136725e"
 dependencies = [
  "darling",
  "ident_case",
@@ -881,9 +876,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.19"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e3a13707ac958681c13b39b458c073d0d9bc8a22cb1b2f4c8e55eb72c13f362"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -1489,9 +1484,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -2089,9 +2084,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libredox"
@@ -2289,6 +2284,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
+]
+
+[[package]]
+name = "multi-core"
+version = "0.1.1"
+dependencies = [
+ "pretty_assertions",
+ "static_assertions",
 ]
 
 [[package]]
@@ -2878,7 +2881,7 @@ version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy 0.8.24",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -3043,7 +3046,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -3070,7 +3073,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror 2.0.12",
 ]
@@ -3239,7 +3242,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -3586,7 +3589,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "254b600e93e9ef00a48382c9f1e86d27884bd9a5489efa4eb9210c20c72e88a6"
 dependencies = [
  "debugid",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "hex",
  "serde",
  "serde_json",
@@ -3747,9 +3750,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -4203,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9590b93e6fcc1739458317cccd391ad3955e2bde8913edf6f95f9e65a8f034"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
@@ -4955,9 +4958,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.6"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63d3fcd9bba44b03821e7d699eeee959f3126dcc4aa8e4ae18ec617c2a5cea10"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
@@ -5049,11 +5052,11 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
 dependencies = [
- "zerocopy-derive 0.8.24",
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -5069,9 +5072,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.24"
+version = "0.8.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -827,6 +827,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1091,6 +1101,25 @@ name = "crossbeam-channel"
 version = "0.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1516,6 +1545,19 @@ name = "glob"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
+name = "globset"
+version = "0.4.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54a1028dfc5f5df5da8a56a73e6c153c9a9708ec57232470703592a3f18e49f5"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
 
 [[package]]
 name = "h2"
@@ -1980,6 +2022,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d89fd380afde86567dfba715db065673989d6253f42b88179abd3eae47bda4b"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata 0.4.9",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,8 +2348,17 @@ dependencies = [
 name = "multi-core"
 version = "0.1.1"
 dependencies = [
+ "async-stream",
+ "base64 0.22.1",
+ "ignore",
+ "miette",
  "pretty_assertions",
  "static_assertions",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "twox-hash",
 ]
 
 [[package]]
@@ -2321,6 +2388,7 @@ dependencies = [
  "indexmap 2.9.0",
  "miette",
  "mockall",
+ "multi-core",
  "multitool-sdk",
  "pingora",
  "pretty_assertions",
@@ -3453,6 +3521,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4391,6 +4468,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7b17f197b3050ba473acf9181f7b1d3b66d1cf7356c6cc57886662276e65908"
+dependencies = [
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4510,6 +4596,16 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,14 @@ path = "src/bin/markdown.rs"
 edition = "2024"
 required-features = ["markdown"]
 
+[workspace]
+members = ["crates/multi-core"]
+
+[workspace.package]
+authors = ["The MultiTool Team"]
+edition = "2024"
+version = "0.1.1"
+
 [dependencies]
 async-stream = "0.3.6"
 async-trait = "0.1.81"
@@ -65,9 +73,13 @@ tracing-subscriber = { version = "0.3.19", features = [
 ] }
 uuid = { version = "1.9", features = ["serde", "v4"] }
 
+[workspace.dependencies]
+pretty_assertions = "1.4"
+static_assertions = "1.1"
+
 [dev-dependencies]
-pretty_assertions = "1.4.0"
-static_assertions = "1.1.0"
+pretty_assertions.workspace = true
+static_assertions.workspace = true
 
 [features]
 proxy = ["dep:pingora"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ edition = "2024"
 version = "0.1.1"
 
 [dependencies]
-async-stream = "0.3.6"
+async-stream.workspace = true
 async-trait = "0.1.81"
 aws-config = { version = "1.1.7", features = ["behavior-version-latest"] }
 aws-sdk-apigateway = "1.50.0"
@@ -48,7 +48,7 @@ failsafe = "1.3.0"
 futures-core = "0.3.31"
 futures-util = "0.3.31"
 indexmap = { version = "2.1.0", features = ["serde"] }
-miette = { version = "7", features = ["fancy"] }
+miette = { workspace = true, features = ["fancy"] }
 mockall = "0.13.1"
 multitool-sdk = { git = "https://github.com/wack/multitool-rust-sdk.git", branch = "trunk" }
 pingora = { version = "0.3", features = ["lb", "proxy"], optional = true }
@@ -57,11 +57,12 @@ reqwest = "0.12.15"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_with = { version = "3.12", features = ["chrono"] }
-thiserror = "2.0"
-tokio = { version = "1.37.0", features = ["full"] }
+thiserror.workspace = true
+tokio = { workspace = true, features = ["full"] }
 tokio-graceful-shutdown = "0.16.0"
-tokio-stream = { version = "0.1", features = ["time"] }
+tokio-stream = { workspace = true, features = ["time"] }
 toml = { version = "0.8.8", features = ["preserve_order"] }
+multi-core = { path = "crates/multi-core" }
 tracing = { version = "0.1.41", features = ["attributes"] }
 tracing-subscriber = { version = "0.3.19", features = [
   "json",
@@ -76,6 +77,15 @@ uuid = { version = "1.9", features = ["serde", "v4"] }
 [workspace.dependencies]
 pretty_assertions = "1.4"
 static_assertions = "1.1"
+base64 = "0.22"
+ignore = "0.4"
+tokio-util = "0.7"
+twox-hash = { version = "2.1", features = ["xxhash32"] }
+tokio = { version = "1.37.0", features = ["full"] }
+miette = { version = "7", features = ["fancy"] }
+tokio-stream = { version = "0.1", features = ["time"] }
+async-stream = "0.3.6"
+thiserror = "2.0"
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -12,6 +12,9 @@ CLI_REFERENCE_DIR = "target/debug/"
 # documentation.
 CLI_REFERENCE_FILE_NAME = "reference.md"
 
+[env.development]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
 [tasks.dev-test-flow]
 dependencies = [
   "pre-build",
@@ -119,6 +122,6 @@ command = "bacon"
 args = [
   "nextest",
   "--",
-  "--lib",
+  "--workspace",
   "@@split(CARGO_MAKE_CARGO_BUILD_TEST_FLAGS, )",
 ]

--- a/crates/multi-core/Cargo.toml
+++ b/crates/multi-core/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "multi-core"
+authors.workspace = true
+edition.workspace = true
+version.workspace = true
+
+[lib]
+name = "multitool_stats"
+
+[dependencies]
+# bon.workspace = true
+# defer-rs.workspace = true
+# derive-getters.workspace = true
+# nutype.workspace = true
+# strum = { workspace = true, features = ["derive"] }
+# strum_macros.workspace = true
+# thiserror.workspace = true
+# tracing = { workspace = true, features = ["attributes"] }
+
+[dev-dependencies]
+pretty_assertions.workspace = true
+static_assertions.workspace = true

--- a/crates/multi-core/Cargo.toml
+++ b/crates/multi-core/Cargo.toml
@@ -5,17 +5,18 @@ edition.workspace = true
 version.workspace = true
 
 [lib]
-name = "multitool_stats"
+name = "multi_core"
 
 [dependencies]
-# bon.workspace = true
-# defer-rs.workspace = true
-# derive-getters.workspace = true
-# nutype.workspace = true
-# strum = { workspace = true, features = ["derive"] }
-# strum_macros.workspace = true
-# thiserror.workspace = true
-# tracing = { workspace = true, features = ["attributes"] }
+base64.workspace = true
+ignore.workspace = true
+tokio-util.workspace = true
+twox-hash = { workspace = true, features = ["xxhash32"] }
+tokio = { workspace = true, features = ["full"] }
+miette.workspace = true
+tokio-stream = { workspace = true, features = ["time"] }
+async-stream.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/multi-core/src/fs/mod.rs
+++ b/crates/multi-core/src/fs/mod.rs
@@ -1,0 +1,36 @@
+use std::path::Path;
+
+use async_stream::stream;
+use miette::{IntoDiagnostic as _, Result};
+use tokio::{fs::File, io::BufReader};
+use tokio_stream::{Stream, StreamExt as _};
+use tokio_util::io::ReaderStream;
+
+/// This function stops reading the file if an Error is encountered,
+/// returning that error as the final element in the stream.
+pub(crate) async fn stream_file<P: AsRef<Path>>(
+    filepath: P,
+) -> impl Stream<Item = Result<Box<[u8]>>> {
+    let path = filepath.as_ref();
+    let file_stream = File::open(path)
+        .await
+        .map(BufReader::new) // buffer the file
+        .map(ReaderStream::new) // convert into a stream
+        .into_diagnostic();
+
+    stream! {
+        // Return a stream with one element if we can't read the file.
+        if let Err(file_err) = file_stream {
+            yield Err(file_err);
+            return;
+        }
+        let mut chunk_stream = file_stream.unwrap();
+
+        while let Some(chunk) = chunk_stream.next().await {
+            let bytes = chunk.map(|bytes| {
+                Box::from(bytes.as_ref())
+            }).into_diagnostic();
+            yield bytes;
+        }
+    }
+}

--- a/crates/multi-core/src/hashing/mod.rs
+++ b/crates/multi-core/src/hashing/mod.rs
@@ -1,1 +1,44 @@
-pub struct Hashing;
+use std::path::{Path, PathBuf};
+
+use miette::{IntoDiagnostic as _, Result};
+use std::hash::Hasher as _;
+use tokio::pin;
+use tokio_stream::StreamExt as _;
+use twox_hash::xxhash32::Hasher as XXHasher;
+
+use crate::fs::stream_file;
+
+/// This is the hashing algorithm for the 32-bit version of
+/// `xxHash`.
+pub struct XXHash32;
+
+pub struct FileHash32 {
+    pub path: PathBuf,
+    pub digest: u32,
+    pub size: u64,
+}
+
+impl XXHash32 {
+    /// The seed is used to initialize the hasher. We fix the
+    /// seed to ensure we always get the same value between executions.
+    const SEED: u32 = 0;
+
+    pub async fn hash_file<P: AsRef<Path>>(filepath: P) -> Result<FileHash32> {
+        // Create the hasher.
+        let mut hasher = XXHasher::with_seed(Self::SEED);
+        let stream = stream_file(filepath.as_ref()).await;
+        pin!(stream);
+
+        // Hash the contents of file.
+        while let Some(bytes) = stream.next().await {
+            hasher.write(bytes?.as_ref());
+        }
+
+        // Dump the output.
+        Ok(FileHash32 {
+            path: filepath.as_ref().to_path_buf(),
+            digest: hasher.finish_32(),
+            size: hasher.total_len(),
+        })
+    }
+}

--- a/crates/multi-core/src/hashing/mod.rs
+++ b/crates/multi-core/src/hashing/mod.rs
@@ -1,0 +1,1 @@
+pub struct Hashing;

--- a/crates/multi-core/src/lib.rs
+++ b/crates/multi-core/src/lib.rs
@@ -1,0 +1,2 @@
+/// Utilities for hashing files and strings.
+pub mod hashing;

--- a/crates/multi-core/src/lib.rs
+++ b/crates/multi-core/src/lib.rs
@@ -1,2 +1,21 @@
+use miette::Diagnostic;
+use thiserror::Error;
+
+/// Utilities for reading and manipulating files.
+pub mod fs;
 /// Utilities for hashing files and strings.
 pub mod hashing;
+
+/// This type aggregates multiple errors into a single instance.
+#[derive(Debug, Error, Diagnostic, Default)]
+#[error("The following errors occurred during execution")]
+pub struct ManyError {
+    #[related]
+    collection: Vec<miette::Error>,
+}
+
+impl ManyError {
+    pub fn append(&mut self, err: miette::Error) {
+        self.collection.push(err);
+    }
+}

--- a/src/utils/circuit_breaker.rs
+++ b/src/utils/circuit_breaker.rs
@@ -17,7 +17,7 @@ use miette::{Result, bail};
 use tokio::time::Duration;
 use tracing::debug;
 
-use super::ManyError;
+use multi_core::ManyError;
 
 /// An `HttpCircuitBreaker` is an implementation of the `CircuitBreaker`
 /// pattern specialized for HTTP requests. HTTP requests typically fail

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -25,16 +25,3 @@ async fn load_config() -> SdkConfig {
 }
 
 static AWS_CONFIG_CELL: OnceCell<SdkConfig> = OnceCell::const_new();
-
-#[derive(Debug, Error, Diagnostic, Default)]
-#[error("The following errors occurred during execution")]
-pub struct ManyError {
-    #[related]
-    collection: Vec<miette::Error>,
-}
-
-impl ManyError {
-    pub fn append(&mut self, err: miette::Error) {
-        self.collection.push(err);
-    }
-}


### PR DESCRIPTION
WIP: Add multi-core crate to offer utilities for our other services and libraries.

Introduce mullti-core crate.

There are more and more code shared between the CLI and Aviary.
This commit introduces a new workspace crate, `multi-core`, which
we can use to share code across multiple repos and services.

For initial inclusion, I copied some code that hashes files, which
we use for the CloudFlare API and will use when we're storing
application config.