### PR TITLE
Add Cloudflare platform configuration support

### DIFF
--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -99,6 +99,38 @@ impl Run {
             .context(workspace_not_found)
     }
 
+    fn load_platform(&self, manifest: &Manifest) -> Result<Box<dyn Platform>> {
+        let config = manifest.config();
+        
+        // If cloudflare config is present, other configs must be None
+        if config.cloudflare().is_some() {
+            if config.monitor().is_some() || config.ingress().is_some() || config.platform().is_some() {
+                return Err(miette!("When using Cloudflare configuration, monitor, ingress, and platform configurations must not be present"));
+            }
+            let cloudflare = config.cloudflare().unwrap();
+            return self.load_platform_from_cloudflare(cloudflare);
+        }
+
+        // Handle regular platform config
+        let platform_config = config
+            .platform()
+            .ok_or_else(|| miette!("No platform configuration found in manifest"))?;
+
+        let platform_builder = PlatformBuilder::new(platform_config);
+        platform_builder.build()
+    }
+
+    fn load_platform_from_cloudflare(&self, cloudflare: &CloudflareConfig) -> Result<Box<dyn Platform>> {
+        if cloudflare.wrangler {
+            let fs = FileSystem::new().map_err(|e| miette!("Failed to initialize filesystem: {}", e))?;
+            let wrangler = cloudflare.load_wrangler(&fs)?;
+            // TODO: Create and return Cloudflare platform using wrangler config
+            todo!("Cloudflare platform creation not yet implemented")
+        } else {
+            Err(miette!("Cloudflare configuration requires wrangler = true"))
+        }
+    }
+
     async fn validate_application(
         &self,
         workspace: &WorkspaceSummary,

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -101,11 +101,16 @@ impl Run {
 
     fn load_platform(&self, manifest: &Manifest) -> Result<Box<dyn Platform>> {
         let config = manifest.config();
-        
+
         // If cloudflare config is present, other configs must be None
         if config.cloudflare().is_some() {
-            if config.monitor().is_some() || config.ingress().is_some() || config.platform().is_some() {
-                return Err(miette!("When using Cloudflare configuration, monitor, ingress, and platform configurations must not be present"));
+            if config.monitor().is_some()
+                || config.ingress().is_some()
+                || config.platform().is_some()
+            {
+                return Err(miette!(
+                    "When using Cloudflare configuration, monitor, ingress, and platform configurations must not be present"
+                ));
             }
             let cloudflare = config.cloudflare().unwrap();
             return self.load_platform_from_cloudflare(cloudflare);
@@ -120,9 +125,13 @@ impl Run {
         platform_builder.build()
     }
 
-    fn load_platform_from_cloudflare(&self, cloudflare: &CloudflareConfig) -> Result<Box<dyn Platform>> {
+    fn load_platform_from_cloudflare(
+        &self,
+        cloudflare: &CloudflareConfig,
+    ) -> Result<Box<dyn Platform>> {
         if cloudflare.wrangler {
-            let fs = FileSystem::new().map_err(|e| miette!("Failed to initialize filesystem: {}", e))?;
+            let fs =
+                FileSystem::new().map_err(|e| miette!("Failed to initialize filesystem: {}", e))?;
             let wrangler = cloudflare.load_wrangler(&fs)?;
             // TODO: Create and return Cloudflare platform using wrangler config
             todo!("Cloudflare platform creation not yet implemented")

--- a/src/fs/manifest/schema.rs
+++ b/src/fs/manifest/schema.rs
@@ -28,7 +28,7 @@ pub fn project_manifest() -> &'static Manifest {
 pub struct Manifest {
     workspace: Option<String>,
     application: Option<String>,
-    config: Option<ConfigSection>,
+    config: ConfigSection,
 }
 
 impl Manifest {
@@ -59,14 +59,33 @@ impl CloudflareConfig {
         fs.load_file(WranglerFile)
     }
 }
+
+impl ConfigSection {
+    pub fn monitor(&self) -> Option<&MonitorConfig> {
+        self.monitor.as_ref()
+    }
+
+    pub fn ingress(&self) -> Option<&IngressConfig> {
+        self.ingress.as_ref()
+    }
+
+    pub fn platform(&self) -> Option<&PlatformConfig> {
+        self.platform.as_ref()
+    }
+
+    pub fn cloudflare(&self) -> Option<&CloudflareConfig> {
+        self.cloudflare.as_ref()
+    }
+}
+
 #[derive(Clone, Default, Deserialize, Serialize, PartialEq, Debug)]
 pub struct ConfigSection {
-    #[serde(default)]
-    monitor: MonitorConfig,
-    #[serde(default)]
-    ingress: IngressConfig,
-    #[serde(default)]
-    platform: PlatformConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    monitor: Option<MonitorConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    ingress: Option<IngressConfig>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    platform: Option<PlatformConfig>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     cloudflare: Option<CloudflareConfig>,
 }
@@ -140,6 +159,7 @@ mod tests {
         "#;
 
         let config: ConfigSection = toml::from_str(config).unwrap();
+        assert!(config.cloudflare.is_some());
         assert!(config.cloudflare.unwrap().wrangler);
     }
 
@@ -152,7 +172,9 @@ application = "multitool"
 
         assert_eq!(observed.workspace, Some("wack".to_string()));
         assert_eq!(observed.application, Some("multitool".to_string()));
-        assert!(observed.config.is_none());
+        assert!(observed.config.monitor.is_none());
+        assert!(observed.config.ingress.is_none());
+        assert!(observed.config.platform.is_none());
     }
 
     #[test]
@@ -177,13 +199,11 @@ region = "us-east-2"
         assert_eq!(observed.workspace, Some("wack".to_string()));
         assert_eq!(observed.application, Some("multitool".to_string()));
 
-        let config = observed.config.expect("Config should be present");
-
         // Check monitor config
-        matches!(config.monitor, MonitorConfig::AwsCloudwatch(_));
+        matches!(observed.config.monitor.expect("Monitor config should be present"), MonitorConfig::AwsCloudwatch(_));
 
         // Check ingress config
-        if let IngressConfig::AwsApiGateway(api_gateway) = config.ingress {
+        if let Some(IngressConfig::AwsApiGateway(api_gateway)) = observed.config.ingress {
             assert_eq!(api_gateway.stage_name, "foo");
             assert_eq!(api_gateway.resource_path, "bar");
             assert_eq!(api_gateway.resource_method, "baz");
@@ -194,7 +214,7 @@ region = "us-east-2"
         }
 
         // Check platform config
-        if let PlatformConfig::AwsLambda(lambda) = config.platform {
+        if let Some(PlatformConfig::AwsLambda(lambda)) = observed.config.platform {
             assert_eq!(lambda.name, "buzz");
             assert_eq!(lambda.region, "us-east-2");
         } else {

--- a/src/fs/manifest/schema.rs
+++ b/src/fs/manifest/schema.rs
@@ -200,7 +200,13 @@ region = "us-east-2"
         assert_eq!(observed.application, Some("multitool".to_string()));
 
         // Check monitor config
-        matches!(observed.config.monitor.expect("Monitor config should be present"), MonitorConfig::AwsCloudwatch(_));
+        matches!(
+            observed
+                .config
+                .monitor
+                .expect("Monitor config should be present"),
+            MonitorConfig::AwsCloudwatch(_)
+        );
 
         // Check ingress config
         if let Some(IngressConfig::AwsApiGateway(api_gateway)) = observed.config.ingress {


### PR DESCRIPTION
This PR adds initial support for Cloudflare platform configuration in the CLI tool. Changes include:

- Made `config` field required in `Manifest` struct
- Made `platform`, `ingress`, and `monitor` fields optional in `ConfigSection`
- Added validation to ensure Cloudflare config cannot coexist with other platform configs
- Added `load_platform_from_cloudflare` method to handle wrangler.toml loading
- Added proper error handling and messages for Cloudflare configuration

TODO: Implement actual Cloudflare platform creation in a future PR.



Created with [**Solver**](https://solverai.com)