### PR TITLE
Add (hidden) multi init command.

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,0 +1,18 @@
+use miette::Result;
+
+use crate::Terminal;
+
+pub struct Init {
+    terminal: Terminal,
+}
+
+impl Init {
+    pub fn new(terminal: Terminal) -> Self {
+        Self { terminal }
+    }
+
+    pub fn dispatch(self) -> Result<()> {
+        println!("Hello, world!");
+        Ok(())
+    }
+}

--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -1,3 +1,4 @@
+pub use init::Init;
 pub use login::Login;
 pub use logout::Logout;
 pub use run::Run;
@@ -6,6 +7,7 @@ pub use version::Version;
 #[cfg(feature = "proxy")]
 pub use proxy::Proxy;
 
+mod init;
 mod login;
 mod logout;
 mod run;

--- a/src/config/command.rs
+++ b/src/config/command.rs
@@ -3,10 +3,10 @@ use miette::Result;
 
 #[cfg(feature = "proxy")]
 use crate::cmd::Proxy;
-use crate::cmd::{Login, Logout, Run, Version};
+use crate::cmd::{Init, Login, Logout, Run, Version};
 use crate::terminal::Terminal;
 
-use super::{LoginSubcommand, RunSubcommand};
+use super::{InitSubcommand, LoginSubcommand, RunSubcommand};
 
 #[cfg(feature = "proxy")]
 use super::ProxySubcommand;
@@ -18,6 +18,8 @@ pub enum MultiCommand {
     /// Log in to the hosted SaaS.
     Login(LoginSubcommand),
     Logout,
+    #[command(hide = true)]
+    Init(InitSubcommand),
     #[cfg(feature = "proxy")]
     Proxy(ProxySubcommand),
     /// Run will execute `multi` in "runner mode", where it will
@@ -33,6 +35,7 @@ impl MultiCommand {
         match self {
             Self::Login(flags) => Login::new(console, flags)?.dispatch(),
             Self::Logout => Logout::new(console).dispatch(),
+            Self::Init(_) => Init::new(console).dispatch(),
             #[cfg(feature = "proxy")]
             Self::Proxy(flags) => Proxy::new(console, flags).dispatch(),
             Self::Run(flags) => Run::new(console, flags)?.dispatch(),

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -1,0 +1,4 @@
+use clap::Args;
+
+#[derive(Args, Clone)]
+pub struct InitSubcommand {}

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -1,4 +1,5 @@
 pub use cli::Cli;
+pub use init::InitSubcommand;
 pub use login::LoginSubcommand;
 pub use proxy::ProxySubcommand;
 pub use run::RunSubcommand;
@@ -6,6 +7,7 @@ pub use run::RunSubcommand;
 mod cli;
 mod colors;
 mod command;
+mod init;
 mod login;
 mod proxy;
 mod run;


### PR DESCRIPTION
This PR adds the new `multi init` command, but hides it from the
CLI help test because it is not yet implemented. You can still run
the command, though the output is not of interest. However, users
won't see this command in the help text, so they can't discover it.
This is kind of like a feature flag for CLI subcommands!