### PR TITLE
Skeleton outline of a function-based state machine.

### DIFF
--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -28,7 +28,7 @@ impl Init {
         // for the code.
         let mut manifest = Manifest::default();
         // Build the start state, passing in the terminal and manifest.
-        let start: &mut dyn StateMachine = &mut Start::builder()
+        let start: &mut dyn InitStateMachine = &mut Start::builder()
             .manifest(&mut manifest)
             .terminal(&mut self.terminal)
             .build();
@@ -48,8 +48,8 @@ struct Start<'a> {
     terminal: &'a mut Terminal,
 }
 
-impl StateMachine for Start<'_> {
-    fn run(&mut self) -> Result<Option<&mut dyn StateMachine>> {
+impl InitStateMachine for Start<'_> {
+    fn run(&mut self) -> Result<Option<&mut dyn InitStateMachine>> {
         println!("Running once.");
         let next = Self::builder()
             .manifest(&mut self.manifest)
@@ -59,14 +59,14 @@ impl StateMachine for Start<'_> {
     }
 }
 
-trait StateMachine {
-    fn run(&mut self) -> Result<Option<&mut dyn StateMachine>>;
+trait InitStateMachine {
+    fn run(&mut self) -> Result<Option<&mut dyn InitStateMachine>>;
 }
 
 #[cfg(test)]
 mod tests {
-    use super::StateMachine;
+    use super::InitStateMachine;
     use static_assertions::assert_obj_safe;
 
-    assert_obj_safe!(StateMachine);
+    assert_obj_safe!(InitStateMachine);
 }

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -1,6 +1,15 @@
+//! The `init` subcommand is implemented as a state machine
+//! that maniputates stack allocated data with each state.
+//! The input is a (potentially empty) manifest file. Each state
+//! asks a question of the user to fill in the manifest file,
+//! like 20 Questions. As you answer more and more questions, you
+//! navigate deeper and deeper into the manifest's structure,
+//! until you reach a leaf node. Each leaf node corresponds to a
+//! field in the manifest.
+
 use miette::Result;
 
-use crate::Terminal;
+use crate::{Terminal, manifest::Manifest};
 
 pub struct Init {
     terminal: Terminal,
@@ -12,7 +21,42 @@ impl Init {
     }
 
     pub fn dispatch(self) -> Result<()> {
-        println!("Hello, world!");
+        // Create a new manifest instance.
+        // TODO: In the future, we should load this manifest
+        // from filesystem. See the git branch `robbie/init`
+        // for the code.
+        let start: Box<dyn InitState<Ctx = Manifest>> = Box::new(());
+        let mut manifest = Manifest::default();
+        let mut state = Some(start);
+        while let Some(next) = state {
+            state = next.run(&mut manifest)?;
+        }
+
         Ok(())
     }
+}
+
+impl<T> InitState for T {
+    type Ctx = Manifest;
+
+    fn run(self, _: &mut Self::Ctx) -> Result<Option<Box<dyn InitState<Ctx = Self::Ctx>>>> {
+        println!("Running once.");
+        Ok(None)
+    }
+}
+
+trait InitState {
+    type Ctx;
+
+    fn run(self, _: &mut Self::Ctx) -> Result<Option<Box<dyn InitState<Ctx = Self::Ctx>>>>;
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::manifest::Manifest;
+
+    use super::InitState;
+    use static_assertions::assert_obj_safe;
+
+    assert_obj_safe!(InitState<Ctx = Manifest>);
 }

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -7,6 +7,7 @@
 //! until you reach a leaf node. Each leaf node corresponds to a
 //! field in the manifest.
 
+use bon::Builder;
 use miette::Result;
 
 use crate::{Terminal, manifest::Manifest};
@@ -20,13 +21,18 @@ impl Init {
         Self { terminal }
     }
 
-    pub fn dispatch(self) -> Result<()> {
+    pub fn dispatch(mut self) -> Result<()> {
         // Create a new manifest instance.
         // TODO: In the future, we should load this manifest
         // from filesystem. See the git branch `robbie/init`
         // for the code.
         let mut manifest = Manifest::default();
-        let start: Box<dyn StateMachine> = Box::new(Start(&mut manifest));
+        // Build the start state, passing in the terminal and manifest.
+        let start: &mut dyn StateMachine = &mut Start::builder()
+            .manifest(&mut manifest)
+            .terminal(&mut self.terminal)
+            .build();
+        // Run the state machine to completion.
         let mut state = Some(start);
         while let Some(next) = state {
             state = next.run()?;
@@ -36,17 +42,25 @@ impl Init {
     }
 }
 
-struct Start<'a>(&'a mut Manifest);
+#[derive(Builder)]
+struct Start<'a> {
+    manifest: &'a mut Manifest,
+    terminal: &'a mut Terminal,
+}
 
-impl<'a> StateMachine for Start<'a> {
-    fn run(self: Box<Self>) -> Result<Option<Box<dyn StateMachine>>> {
+impl StateMachine for Start<'_> {
+    fn run(&mut self) -> Result<Option<&mut dyn StateMachine>> {
         println!("Running once.");
+        let next = Self::builder()
+            .manifest(&mut self.manifest)
+            .terminal(&mut self.terminal)
+            .build();
         Ok(None)
     }
 }
 
 trait StateMachine {
-    fn run(self: Box<Self>) -> Result<Option<Box<dyn StateMachine>>>;
+    fn run(&mut self) -> Result<Option<&mut dyn StateMachine>>;
 }
 
 #[cfg(test)]

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -25,38 +25,34 @@ impl Init {
         // TODO: In the future, we should load this manifest
         // from filesystem. See the git branch `robbie/init`
         // for the code.
-        let start: Box<dyn InitState<Ctx = Manifest>> = Box::new(());
         let mut manifest = Manifest::default();
+        let start: Box<dyn StateMachine> = Box::new(Start(&mut manifest));
         let mut state = Some(start);
         while let Some(next) = state {
-            state = next.run(&mut manifest)?;
+            state = next.run()?;
         }
 
         Ok(())
     }
 }
 
-impl<T> InitState for T {
-    type Ctx = Manifest;
+struct Start<'a>(&'a mut Manifest);
 
-    fn run(self, _: &mut Self::Ctx) -> Result<Option<Box<dyn InitState<Ctx = Self::Ctx>>>> {
+impl<'a> StateMachine for Start<'a> {
+    fn run(self: Box<Self>) -> Result<Option<Box<dyn StateMachine>>> {
         println!("Running once.");
         Ok(None)
     }
 }
 
-trait InitState {
-    type Ctx;
-
-    fn run(self, _: &mut Self::Ctx) -> Result<Option<Box<dyn InitState<Ctx = Self::Ctx>>>>;
+trait StateMachine {
+    fn run(self: Box<Self>) -> Result<Option<Box<dyn StateMachine>>>;
 }
 
 #[cfg(test)]
 mod tests {
-    use crate::manifest::Manifest;
-
-    use super::InitState;
+    use super::StateMachine;
     use static_assertions::assert_obj_safe;
 
-    assert_obj_safe!(InitState<Ctx = Manifest>);
+    assert_obj_safe!(StateMachine);
 }


### PR DESCRIPTION
Skeleton outline of a function-based state machine.

This commit introduces the general idea of a function-based
state machine for asking & answering questions to fill in the
manifest. This state machine makes it very easy to isolate
the current context from the rest of the otherwise messy questioning
logic.

Currently, it allows you to pass a mutable Manifest reference around,
letting each state edit the manifest as more information is gathered.
Right now, there is only one implementation; a global implementation
that shows we can define the StateMachine trait on all types.

Next, we plan to narrow this down into function types (closures) that
implement the necessary parameters. This will give us a pleasant
syntactic sugar to define new states as functions.

Implement a more sound interface type for the StateMachine.

This commit chnages the state machine's definition to allow each
of the states to hold onto context, like a mutable reference to
the manifest file, for instance.

Borrow manifest correctly.

This commit changes the borrowing restrictions on the manifest
and terminal pointers so we can actually pass these values from
one state to another, which previously would not have been allowed,
and would have immediately broken once we added a second state.