### PR TITLE
Validate Manifest Missing before Init

### DIFF
--- a/src/adapters/backend/mod.rs
+++ b/src/adapters/backend/mod.rs
@@ -78,6 +78,10 @@ impl BackendClient {
         })
     }
 
+    pub fn origin(&self) -> &str {
+        &self.conf.base_path
+    }
+
     pub fn is_authenicated(&self) -> Result<()> {
         if self.session.clone().is_some_and(Session::is_not_expired) {
             return Ok(());

--- a/src/adapters/backend/mod.rs
+++ b/src/adapters/backend/mod.rs
@@ -90,6 +90,19 @@ impl BackendClient {
         }
     }
 
+    pub(crate) async fn list_workspaces(&self) -> Result<Vec<WorkspaceSummary>> {
+        self.is_authenicated()?;
+        let workspaces: Vec<_> = self
+            .client
+            .workspaces_api()
+            .list_workspaces(None)
+            .await
+            .into_diagnostic()?
+            .workspaces;
+
+        Ok(workspaces)
+    }
+
     pub(crate) async fn lock_state(
         &self,
         meta: &RolloutMetadata,

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -8,37 +8,69 @@
 //! field in the manifest.
 
 use bon::Builder;
-use miette::Result;
+use miette::{IntoDiagnostic, Result};
+use tokio::runtime::Runtime;
+use tracing::info;
 
-use crate::{Terminal, manifest::Manifest};
+use crate::{
+    Terminal,
+    adapters::BackendClient,
+    config::InitSubcommand,
+    fs::FileSystem,
+    manifest::{InitTomlManifest, Manifest, TomlManifest},
+};
 
 pub struct Init {
     terminal: Terminal,
+    backend: BackendClient,
 }
 
 impl Init {
-    pub fn new(terminal: Terminal) -> Self {
-        Self { terminal }
+    pub fn new(terminal: Terminal, flags: InitSubcommand) -> Result<Self> {
+        let origin = flags.origin().as_deref();
+        let backend = BackendClient::new(origin, None)?;
+        Ok(Self { terminal, backend })
     }
 
     pub fn dispatch(mut self) -> Result<()> {
-        // Create a new manifest instance.
-        // TODO: In the future, we should load this manifest
-        // from filesystem. See the git branch `robbie/init`
-        // for the code.
-        let mut manifest = Manifest::default();
-        // Build the start state, passing in the terminal and manifest.
-        let start: &mut dyn InitStateMachine = &mut Start::builder()
-            .manifest(&mut manifest)
-            .terminal(&mut self.terminal)
-            .build();
-        // Run the state machine to completion.
-        let mut state = Some(start);
-        while let Some(next) = state {
-            state = next.run()?;
-        }
+        // Kick off the async runtime.
+        let rt = Runtime::new().into_diagnostic()?;
+        let _guard = rt.enter();
+        rt.block_on(async {
+            let mut fs = FileSystem::new()?;
+            // Exit early if there's already a project manifest.
+            //
+            // For now, we don't allow users to use init to
+            // edit their manifest (because we can't preserve
+            // comments right Serde right now...)
+            // TODO: Upgrade our config-file reading to use
+            // the toml and toml_edit crates to preserve comments
+            // in the TOML files we read.
+            // https://docs.rs/toml_edit/latest/toml_edit/
+            if let Ok(_) = fs.project_manifest() {
+                info!("It looks like you already have an initialized project manifest. Exiting.");
+                return Ok(());
+            }
+            info!("No project manifest file found. Let's create one!");
+            // Create a new manifest instance.
+            let mut manifest = Manifest::default();
 
-        Ok(())
+            // Build the start state, passing in the terminal and manifest.
+            let start: &mut dyn InitStateMachine = &mut Start::builder()
+                .manifest(&mut manifest)
+                .terminal(&mut self.terminal)
+                .fs(&mut fs)
+                .build();
+
+            // Run the state machine to completion.
+            let mut state = Some(start);
+            while let Some(next) = state {
+                state = next.run()?;
+            }
+
+            // Dump the file to disk.
+            fs.save_file(&InitTomlManifest, &manifest)
+        })
     }
 }
 
@@ -46,6 +78,7 @@ impl Init {
 struct Start<'a> {
     manifest: &'a mut Manifest,
     terminal: &'a mut Terminal,
+    fs: &'a mut FileSystem,
 }
 
 impl InitStateMachine for Start<'_> {
@@ -54,6 +87,7 @@ impl InitStateMachine for Start<'_> {
         let next = Self::builder()
             .manifest(&mut self.manifest)
             .terminal(&mut self.terminal)
+            .fs(self.fs)
             .build();
         Ok(None)
     }

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -128,7 +128,7 @@ impl CheckLogin {
         let creds = backend.exchange_creds(&email, &password).await?;
         self.fs.save_file(&SessionFile, &creds)?;
         self.terminal.login_successful()?;
-        info!("Now that you're logged in, we can continue.");
+        info!("Now that you're logged in, let's continue.");
         Ok(creds)
     }
 }
@@ -211,7 +211,7 @@ impl InitStateMachine for PromptWorkspace {
         // To give them that option, we have to add a new element
         // to the list.
         let mut options = workspace_names.clone();
-        options.push("Create new".to_owned());
+        options.push("+ Create new workspace".to_owned());
         // Now, we can prompt the user to select an option.
         info!("Which workspace would you like to use?");
         let selection = self.terminal.prompt_workspace_selection(options.as_slice());

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -44,7 +44,7 @@ impl Init {
         rt.block_on(async {
             let fs = FileSystem::new()?;
 
-            // Exit early if there's already a project manifest.
+            // Exit early if there's already a application manifest.
             //
             // For now, we don't allow users to use init to
             // edit their manifest (because we can't preserve
@@ -53,11 +53,13 @@ impl Init {
             // the toml and toml_edit crates to preserve comments
             // in the TOML files we read.
             // https://docs.rs/toml_edit/latest/toml_edit/
-            if let Ok(_) = fs.project_manifest() {
-                info!("It looks like you already have an initialized project manifest. Exiting.");
+            if let Ok(_) = fs.application_manifest() {
+                info!(
+                    "It looks like you already have an initialized application manifest. Exiting."
+                );
                 return Ok(());
             }
-            info!("No project manifest file found. Let's create one!");
+            info!("No application manifest file found. Let's create one!");
             // Create a new manifest instance.
             let manifest = Arc::new(Mutex::new(Manifest::default()));
             let terminal = Arc::new(self.terminal);

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -7,37 +7,43 @@
 //! until you reach a leaf node. Each leaf node corresponds to a
 //! field in the manifest.
 
+use std::sync::Arc;
+
+use async_trait::async_trait;
 use bon::Builder;
 use miette::{IntoDiagnostic, Result};
 use tokio::runtime::Runtime;
 use tracing::info;
 
 use crate::{
-    Terminal,
+    MULTITOOL_ORIGIN, Terminal,
     adapters::BackendClient,
     config::InitSubcommand,
-    fs::FileSystem,
-    manifest::{InitTomlManifest, Manifest, TomlManifest},
+    fs::{FileSystem, Session, SessionFile},
+    manifest::{InitTomlManifest, Manifest},
 };
 
 pub struct Init {
     terminal: Terminal,
-    backend: BackendClient,
+    origin: String,
 }
 
 impl Init {
     pub fn new(terminal: Terminal, flags: InitSubcommand) -> Result<Self> {
-        let origin = flags.origin().as_deref();
-        let backend = BackendClient::new(origin, None)?;
-        Ok(Self { terminal, backend })
+        let origin = flags
+            .origin()
+            .clone()
+            .unwrap_or(MULTITOOL_ORIGIN.to_owned());
+        Ok(Self { terminal, origin })
     }
 
-    pub fn dispatch(mut self) -> Result<()> {
+    pub fn dispatch(self) -> Result<()> {
         // Kick off the async runtime.
         let rt = Runtime::new().into_diagnostic()?;
         let _guard = rt.enter();
         rt.block_on(async {
-            let mut fs = FileSystem::new()?;
+            let fs = FileSystem::new()?;
+
             // Exit early if there's already a project manifest.
             //
             // For now, we don't allow users to use init to
@@ -53,54 +59,157 @@ impl Init {
             }
             info!("No project manifest file found. Let's create one!");
             // Create a new manifest instance.
-            let mut manifest = Manifest::default();
-
-            // Build the start state, passing in the terminal and manifest.
-            let start: &mut dyn InitStateMachine = &mut Start::builder()
-                .manifest(&mut manifest)
-                .terminal(&mut self.terminal)
-                .fs(&mut fs)
+            let manifest = Arc::new(Manifest::default());
+            let terminal = Arc::new(self.terminal);
+            let start = Start::builder()
+                .manifest(manifest)
+                .fs(fs.clone())
+                .terminal(terminal)
+                .origin(self.origin.clone())
                 .build();
+            let mut state = State::Next(Box::new(start));
 
-            // Run the state machine to completion.
-            let mut state = Some(start);
-            while let Some(next) = state {
-                state = next.run()?;
-            }
+            let manifest = loop {
+                match state {
+                    State::Next(mut next) => state = next.run().await,
+                    State::Done(manifest) => break manifest,
+                    State::Err(report) => return Err(report),
+                }
+            };
 
             // Dump the file to disk.
-            fs.save_file(&InitTomlManifest, &manifest)
+            fs.save_file(&InitTomlManifest, &*manifest)
         })
     }
 }
 
 #[derive(Builder)]
-struct Start<'a> {
-    manifest: &'a mut Manifest,
-    terminal: &'a mut Terminal,
-    fs: &'a mut FileSystem,
+struct Start {
+    manifest: Arc<Manifest>,
+    terminal: Arc<Terminal>,
+    origin: String,
+    fs: FileSystem,
 }
 
-impl InitStateMachine for Start<'_> {
-    fn run(&mut self) -> Result<Option<&mut dyn InitStateMachine>> {
-        println!("Running once.");
-        let next = Self::builder()
-            .manifest(&mut self.manifest)
-            .terminal(&mut self.terminal)
-            .fs(self.fs)
+#[async_trait]
+impl InitStateMachine for Start {
+    type Output = Arc<Manifest>;
+
+    async fn run(&mut self) -> State<Self::Output> {
+        let next = CheckLogin::builder()
+            .manifest(self.manifest.clone())
+            .fs(self.fs.clone())
+            .terminal(self.terminal.clone())
+            .origin(self.origin.clone())
             .build();
-        Ok(None)
+        State::Next(Box::new(next))
     }
 }
 
+#[derive(Builder)]
+struct CheckLogin {
+    manifest: Arc<Manifest>,
+    terminal: Arc<Terminal>,
+    fs: FileSystem,
+    origin: String,
+}
+
+impl CheckLogin {
+    async fn prompt_login(&self) -> Result<Session> {
+        let email = self.terminal.prompt_email();
+        let password = self.terminal.prompt_password();
+        let backend = BackendClient::new(Some(&self.origin), None)?;
+        let creds = backend.exchange_creds(&email, &password).await?;
+        self.fs.save_file(&SessionFile, &creds)?;
+        self.terminal.login_successful()?;
+        info!("Now that you're logged in, we can continue.");
+        Ok(creds)
+    }
+}
+
+impl<T> From<miette::Report> for State<T> {
+    fn from(value: miette::Report) -> Self {
+        Self::Err(value)
+    }
+}
+
+#[async_trait]
+impl InitStateMachine for CheckLogin {
+    type Output = Arc<Manifest>;
+
+    async fn run(&mut self) -> State<Self::Output> {
+        // Check to ensure the user is logged in.
+        // If they're already logged in, then we can continue
+        // forward with the `init` process.
+        info!("Checking to see if you're logged in");
+        let session = match self.fs.load_file(SessionFile) {
+            Ok(session) => Ok(session),
+            // If they're not logged in, then we have to log
+            // them in and get back a session instance so we
+            // can build the Backend client.
+            Err(_) => self.prompt_login().await,
+        };
+
+        // Now that they're logged in, we can create a backend
+        // client using their auth information.
+        let origin = Some(self.origin.as_ref());
+        let backend = match session {
+            Ok(value) => BackendClient::new(origin, Some(value)),
+            Err(err) => return State::Err(err),
+        };
+        // Unwrap the backend client.
+        let backend = match backend {
+            Ok(backend) => backend,
+            Err(err) => return State::Err(err),
+        };
+        // Now, we can ask the user about which workspace they
+        // want to operate on.
+        let next = PromptWorkspace::builder()
+            .manifest(self.manifest.clone())
+            .terminal(self.terminal.clone())
+            .fs(self.fs.clone())
+            .backend(backend)
+            .build();
+
+        State::Next(Box::new(next))
+    }
+}
+
+#[derive(Builder)]
+struct PromptWorkspace {
+    manifest: Arc<Manifest>,
+    terminal: Arc<Terminal>,
+    fs: FileSystem,
+    backend: BackendClient,
+}
+
+#[async_trait]
+impl InitStateMachine for PromptWorkspace {
+    type Output = Arc<Manifest>;
+
+    async fn run(&mut self) -> State<Self::Output> {
+        State::Done(self.manifest.clone())
+    }
+}
+
+enum State<T> {
+    Done(T),
+    Next(Box<dyn InitStateMachine<Output = T>>),
+    Err(miette::Report),
+}
+
+#[async_trait]
 trait InitStateMachine {
-    fn run(&mut self) -> Result<Option<&mut dyn InitStateMachine>>;
+    type Output;
+    async fn run(&mut self) -> State<Self::Output>;
 }
 
 #[cfg(test)]
 mod tests {
+    use crate::manifest::Manifest;
+
     use super::InitStateMachine;
     use static_assertions::assert_obj_safe;
 
-    assert_obj_safe!(InitStateMachine);
+    assert_obj_safe!(InitStateMachine<Output = Manifest>);
 }

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use bon::Builder;
 use miette::{IntoDiagnostic, Result};
-use tokio::runtime::Runtime;
+use tokio::{runtime::Runtime, sync::Mutex};
 use tracing::info;
 
 use crate::{
@@ -59,7 +59,7 @@ impl Init {
             }
             info!("No project manifest file found. Let's create one!");
             // Create a new manifest instance.
-            let manifest = Arc::new(Manifest::default());
+            let manifest = Arc::new(Mutex::new(Manifest::default()));
             let terminal = Arc::new(self.terminal);
             let start = Start::builder()
                 .manifest(manifest)
@@ -76,16 +76,20 @@ impl Init {
                     State::Err(report) => return Err(report),
                 }
             };
+            // Now that we've edited the inner manifest and finalized
+            // the value, we can copy the guts out from inside the mutex.
+            let manifest_guard = manifest.lock().await;
+            let final_manifest = manifest_guard.clone();
 
             // Dump the file to disk.
-            fs.save_file(&InitTomlManifest, &*manifest)
+            fs.save_file(&InitTomlManifest, &final_manifest)
         })
     }
 }
 
 #[derive(Builder)]
 struct Start {
-    manifest: Arc<Manifest>,
+    manifest: Arc<Mutex<Manifest>>,
     terminal: Arc<Terminal>,
     origin: String,
     fs: FileSystem,
@@ -93,7 +97,7 @@ struct Start {
 
 #[async_trait]
 impl InitStateMachine for Start {
-    type Output = Arc<Manifest>;
+    type Output = Arc<Mutex<Manifest>>;
 
     async fn run(&mut self) -> State<Self::Output> {
         let next = CheckLogin::builder()
@@ -108,7 +112,7 @@ impl InitStateMachine for Start {
 
 #[derive(Builder)]
 struct CheckLogin {
-    manifest: Arc<Manifest>,
+    manifest: Arc<Mutex<Manifest>>,
     terminal: Arc<Terminal>,
     fs: FileSystem,
     origin: String,
@@ -135,7 +139,7 @@ impl<T> From<miette::Report> for State<T> {
 
 #[async_trait]
 impl InitStateMachine for CheckLogin {
-    type Output = Arc<Manifest>;
+    type Output = Arc<Mutex<Manifest>>;
 
     async fn run(&mut self) -> State<Self::Output> {
         // Check to ensure the user is logged in.
@@ -177,7 +181,7 @@ impl InitStateMachine for CheckLogin {
 
 #[derive(Builder)]
 struct PromptWorkspace {
-    manifest: Arc<Manifest>,
+    manifest: Arc<Mutex<Manifest>>,
     terminal: Arc<Terminal>,
     fs: FileSystem,
     backend: BackendClient,
@@ -185,7 +189,65 @@ struct PromptWorkspace {
 
 #[async_trait]
 impl InitStateMachine for PromptWorkspace {
-    type Output = Arc<Manifest>;
+    type Output = Arc<Mutex<Manifest>>;
+
+    async fn run(&mut self) -> State<Self::Output> {
+        debug_assert!(self.backend.is_authenicated().is_ok());
+        // Now that we have an authenticated client, we
+        // can read their workspaces and ask if they want
+        // to use an existing workspace or create a new one.
+        let workspaces = match self.backend.list_workspaces().await {
+            Ok(workspaces) => workspaces,
+            Err(err) => return State::Err(err),
+        };
+        let workspace_names: Vec<_> = workspaces
+            .into_iter()
+            .map(|workspace| workspace.display_name)
+            .collect();
+        // We're going to prompt the user to pick out their workspace
+        // from the list, or to create a new one.
+        // To give them that option, we have to add a new element
+        // to the list.
+        let mut options = workspace_names.clone();
+        options.push("Create new".to_owned());
+        // Now, we can prompt the user to select an option.
+        info!("Which workspace would you like to use?");
+        let selection = self.terminal.prompt_workspace_selection(options.as_slice());
+        if selection < workspace_names.len() {
+            // The user has selected an existing workspace.
+            // Set this field and continue.
+            let workspace = workspace_names[selection].clone();
+            let mut manifest_guard = self.manifest.lock().await;
+            manifest_guard.set_workspace(workspace);
+            drop(manifest_guard);
+            // Awesome, now we can move on to the application id.
+            let next = PromptApplication::builder()
+                .manifest(self.manifest.clone())
+                .fs(self.fs.clone())
+                .terminal(self.terminal.clone())
+                .backend(self.backend.clone())
+                .build();
+            State::Next(Box::new(next))
+        } else {
+            // The user has decided to create a new workspace.
+            // Prompt for the workspace name, create a new workspace,
+            // and then set the field and continue.
+            todo!();
+        }
+    }
+}
+
+#[derive(Builder)]
+struct PromptApplication {
+    manifest: Arc<Mutex<Manifest>>,
+    terminal: Arc<Terminal>,
+    fs: FileSystem,
+    backend: BackendClient,
+}
+
+#[async_trait]
+impl InitStateMachine for PromptApplication {
+    type Output = Arc<Mutex<Manifest>>;
 
     async fn run(&mut self) -> State<Self::Output> {
         State::Done(self.manifest.clone())

--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -1,6 +1,6 @@
 use crate::adapters::backend::{ApplicationId, CreateRolloutParams, WorkspaceId};
 use crate::adapters::{BoxedIngress, BoxedMonitor, BoxedPlatform, RolloutMetadata};
-use crate::fs::{FileSystem, SessionFile, project_manifest};
+use crate::fs::{FileSystem, SessionFile, application_manifest};
 use crate::manifest::Manifest;
 use crate::subsystems::CONTROLLER_SUBSYSTEM_NAME;
 use crate::{ControllerSubsystem, adapters::BackendClient, config::RunSubcommand};
@@ -45,7 +45,7 @@ impl Run {
     pub fn new(terminal: Terminal, args: RunSubcommand) -> Result<Self> {
         let fs = FileSystem::new().unwrap();
         let session = fs.load_file(SessionFile)?;
-        let manifest = project_manifest().clone();
+        let manifest = application_manifest().clone();
         let backend = BackendClient::new(args.origin(), Some(session))?;
         let override_workspace_name = args.workspace().map(ToString::to_string);
         let override_application_name = args.application().map(ToString::to_string);

--- a/src/config/command.rs
+++ b/src/config/command.rs
@@ -18,6 +18,7 @@ pub enum MultiCommand {
     /// Log in to the hosted SaaS.
     Login(LoginSubcommand),
     Logout,
+    /// Initialize a new project or prepare the configuration of an existing one
     #[command(hide = true)]
     Init(InitSubcommand),
     #[cfg(feature = "proxy")]
@@ -35,7 +36,7 @@ impl MultiCommand {
         match self {
             Self::Login(flags) => Login::new(console, flags)?.dispatch(),
             Self::Logout => Logout::new(console).dispatch(),
-            Self::Init(_) => Init::new(console).dispatch(),
+            Self::Init(flags) => Init::new(console, flags)?.dispatch(),
             #[cfg(feature = "proxy")]
             Self::Proxy(flags) => Proxy::new(console, flags).dispatch(),
             Self::Run(flags) => Run::new(console, flags)?.dispatch(),

--- a/src/config/command.rs
+++ b/src/config/command.rs
@@ -18,7 +18,7 @@ pub enum MultiCommand {
     /// Log in to the hosted SaaS.
     Login(LoginSubcommand),
     Logout,
-    /// Initialize a new project or prepare the configuration of an existing one
+    /// Initialize a new application or prepare the configuration of an existing one
     #[command(hide = true)]
     Init(InitSubcommand),
     #[cfg(feature = "proxy")]

--- a/src/config/init.rs
+++ b/src/config/init.rs
@@ -1,4 +1,10 @@
 use clap::Args;
+use derive_getters::Getters;
 
-#[derive(Args, Clone)]
-pub struct InitSubcommand {}
+use crate::MULTITOOL_ORIGIN;
+
+#[derive(Args, Getters, Clone)]
+pub struct InitSubcommand {
+    #[arg(long, short = 'o', default_value = Some(MULTITOOL_ORIGIN))]
+    origin: Option<String>,
+}

--- a/src/fs/manifest/mod.rs
+++ b/src/fs/manifest/mod.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-pub use schema::{CloudflareConfig, Manifest, project_manifest};
+pub use schema::{CloudflareConfig, Manifest, application_manifest};
 
 use super::{DirectoryType, file::StaticFile};
 
@@ -28,7 +28,7 @@ pub struct TomlManifest;
 
 /// A manifest that was originally loaded from a TOML file.
 impl StaticFile for TomlManifest {
-    const DIR: DirectoryType = DirectoryType::Project;
+    const DIR: DirectoryType = DirectoryType::ApplicationRoot;
     const NAME: &'static str = MANIFEST_PREFIX;
     const EXTENSION: &'static str = MANIFEST_EXTENSIONS[0];
 
@@ -39,7 +39,7 @@ impl StaticFile for TomlManifest {
 pub struct JsonManifest;
 
 impl StaticFile for JsonManifest {
-    const DIR: DirectoryType = DirectoryType::Project;
+    const DIR: DirectoryType = DirectoryType::ApplicationRoot;
     const NAME: &'static str = MANIFEST_PREFIX;
     const EXTENSION: &'static str = MANIFEST_EXTENSIONS[1];
 

--- a/src/fs/manifest/schema.rs
+++ b/src/fs/manifest/schema.rs
@@ -20,14 +20,14 @@ use crate::{
 };
 use miette::Result;
 
-/// The project manifest only needs to be loaded once, so we
+/// The application manifest only needs to be loaded once, so we
 /// cache it as a global singleton.
-static PROJECT_MANIFEST: OnceLock<Manifest> = OnceLock::new();
+static APPLICATION_MANIFEST: OnceLock<Manifest> = OnceLock::new();
 
-/// Return the project's manifest file, or an empty manifest if none
+/// Return the application's manifest file, or an empty manifest if none
 /// is found. Use the globally available cached file.
-pub fn project_manifest() -> &'static Manifest {
-    PROJECT_MANIFEST.get_or_init(Manifest::load_or_default)
+pub fn application_manifest() -> &'static Manifest {
+    APPLICATION_MANIFEST.get_or_init(Manifest::load_or_default)
 }
 
 #[derive(Error, Debug, Diagnostic)]
@@ -62,11 +62,11 @@ pub struct Manifest {
 }
 
 impl Manifest {
-    /// Attempts to read a config file for this project, and
+    /// Attempts to read a config file for this application, and
     /// returns an empty manifest file if none is found.
     pub(crate) fn load_or_default() -> Self {
         FileSystem::new().map_or(Self::default(), |fs| {
-            fs.project_manifest().unwrap_or_default()
+            fs.application_manifest().unwrap_or_default()
         })
     }
 
@@ -407,7 +407,7 @@ impl CloudflareConfig {
         }
 
         // Finally, default to current working directory
-        let current_dir = match fs.project_dir() {
+        let current_dir = match fs.application_dir() {
             Err(err) => Err(err),
             Ok(Some(path)) => Ok(path),
             Ok(None) => std::env::current_dir()

--- a/src/fs/manifest/schema.rs
+++ b/src/fs/manifest/schema.rs
@@ -74,6 +74,10 @@ impl Manifest {
         self.workspace.as_deref()
     }
 
+    pub fn set_workspace<T: AsRef<str>>(&mut self, value: T) {
+        self.workspace = Some(value.as_ref().to_owned());
+    }
+
     pub fn application(&self) -> Option<&str> {
         self.application.as_deref()
     }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 pub(crate) use file::File;
-pub(crate) use manifest::project_manifest;
+pub(crate) use manifest::application_manifest;
 pub(crate) use session::{Session, SessionFile, UserCreds};
 
 use manifest::{JsonManifest, Manifest, TomlManifest};
@@ -61,9 +61,9 @@ impl FileSystem {
         }
     }
 
-    /// Load the project manifest file, looking for manifests in
+    /// Load the application manifest file, looking for manifests in
     /// priority order up the file hierarchy.
-    pub fn project_manifest(&self) -> Result<Manifest, ManifestMissing> {
+    pub fn application_manifest(&self) -> Result<Manifest, ManifestMissing> {
         // • Attempt to load a TOML manifest. Fallback to JSON.
         let toml_manifest = self.load_file(TomlManifest);
         let json_manifest = self.load_file(JsonManifest);
@@ -75,8 +75,8 @@ impl FileSystem {
         Ok(manifest_box)
     }
 
-    /// The project directory is the first directory with a MultiTool manifest
-    /// staritng in the current directory and walking up the directory
+    /// The application directory is the first directory with a MultiTool manifest
+    /// starting in the current directory and walking up the directory
     /// tree until one is observed.
     /// `Ok(Some(_))`` is returned when the file is found successfully.
     /// `Ok(None)` is returned when the file cannot be found.
@@ -84,7 +84,7 @@ impl FileSystem {
     /// occurred, like the file could not be read due to insufficient
     /// permissions, or the pwd is outside of the bounds of the filesystem.
     /// This function only checks if the file exists, not if the file is valid.
-    pub fn project_dir(&self) -> Result<Option<PathBuf>> {
+    pub fn application_dir(&self) -> Result<Option<PathBuf>> {
         // • Check this directory for the `MultiTool.toml` manifest file. If not found,
         //   traverse upward until found.
         let current_dir = std::env::current_dir().into_diagnostic()?;
@@ -159,7 +159,7 @@ impl FileSystem {
     fn dir(&self, typ: DirectoryType) -> Result<PathBuf> {
         match typ {
             DirectoryType::Cache => Ok(self.xdg_dirs.cache_dir().to_path_buf()),
-            DirectoryType::Project => self.project_dir()?.ok_or(ManifestMissing.into()),
+            DirectoryType::ApplicationRoot => self.application_dir()?.ok_or(ManifestMissing.into()),
             DirectoryType::Pwd => std::env::current_dir().into_diagnostic(),
             DirectoryType::Data => Ok(self.xdg_dirs.data_dir().to_path_buf()),
         }
@@ -199,13 +199,13 @@ pub enum DirectoryType {
     Cache,
     /// Persistent data lives here between runs.
     Data,
-    /// The project directory is the dir that contains the manifest
+    /// The application root directory is the dir that contains the manifest
     /// file relevant to the current operating context. It's usually
-    /// the nearest wack.toml file, starting in the pwd and crawling
-    /// up the directory tree until its found.
-    Project,
+    /// the directory containing the nearest `MultiTool.toml` file, starting
+    /// in the pwd and crawling up the directory tree until its found.
+    ApplicationRoot,
     /// Sometimes, we need to create new files from scratch in the
     /// working directory. This extension is for cases when we're
-    /// not interested in the project root. e.g. `wack init`
+    /// not interested in the application root. e.g. `multi init`
     Pwd,
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -26,6 +26,7 @@ const APPLICATION_NAME: &str = "multi";
 
 /// An abstraction over the user's filesystem ensuring mediated
 /// access to the most commonly used files.
+#[derive(Clone)]
 pub struct FileSystem {
     /// OS-specific file locations for standard operations,
     /// respecting $XDG_CONFIG and similar variables, and falling

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -134,7 +134,7 @@ impl FileSystem {
         Ok(document)
     }
 
-    /// Open the file and deserialize it with serde.
+    /// Store the file, using its canonical path.
     pub(crate) fn save_file<F: File>(&self, file: &F, blob: &F::Data) -> Result<()> {
         // • Get the path to the file.
         let path = file.path(self)?;

--- a/src/fs/wrangler.rs
+++ b/src/fs/wrangler.rs
@@ -26,7 +26,7 @@ pub struct WranglerFile;
 
 impl StaticFile for WranglerFile {
     type Data = Wrangler;
-    const DIR: DirectoryType = DirectoryType::Project;
+    const DIR: DirectoryType = DirectoryType::ApplicationRoot;
     const NAME: &'static str = "wrangler";
     const EXTENSION: &'static str = "toml";
 }

--- a/src/terminal/dest.rs
+++ b/src/terminal/dest.rs
@@ -9,7 +9,7 @@ use super::theme::{SIMPLE_THEME, colorful_theme};
 pub(super) struct TermDestination {
     term: Term,
     allow_color: bool,
-    theme: &'static dyn Theme,
+    theme: &'static (dyn Theme + Send + Sync),
 }
 
 impl TermDestination {
@@ -38,7 +38,7 @@ impl TermDestination {
             .color_preference()
             .unwrap_or_else(colors_enabled);
         // Pick the theme based on the user's color preference.
-        let theme: &'static dyn Theme = if allow_color {
+        let theme: &'static (dyn Theme + Send + Sync) = if allow_color {
             colorful_theme()
         } else {
             SIMPLE_THEME
@@ -62,7 +62,7 @@ impl TermDestination {
             .color_preference()
             .unwrap_or_else(colors_enabled_stderr);
         // Pick the theme based on the user's color preference.
-        let theme: &'static dyn Theme = if allow_color {
+        let theme: &'static (dyn Theme + Send + Sync) = if allow_color {
             colorful_theme()
         } else {
             SIMPLE_THEME

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -1,4 +1,4 @@
-use dialoguer::{Input, Password};
+use dialoguer::{Input, Password, Select};
 use logging::setup_logger;
 use miette::{DebugReportHandler, GraphicalReportHandler, IntoDiagnostic, Result};
 
@@ -94,6 +94,14 @@ impl Terminal {
     pub fn prompt_email(&self) -> String {
         Input::with_theme(self.stdout.theme())
             .with_prompt("Email")
+            .interact()
+            .unwrap()
+    }
+
+    pub fn prompt_workspace_selection(&self, items: &[String]) -> usize {
+        Select::with_theme(self.stdout.theme())
+            .items(items)
+            .with_prompt("Workspace")
             .interact()
             .unwrap()
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -51,7 +51,7 @@ impl Terminal {
     pub fn init_check(&self) -> Result<()> {
         self.stdout
             .term()
-            .write_line("Checking if the project is already initialized")
+            .write_line("Checking if the application is already initialized")
             .into_diagnostic()
     }
 


### PR DESCRIPTION
Validate Manifest Missing before Init

This commit ensures that there is no manifest file found before
initializing a new manifest to prevent us from overwriting an
existing manifest, or accidently dropping the comments in a
manifest.

Add state to check if the user is logged in.

This commit introduces a new state that checks
whether the user is logged in. If they're not, we prompt
them for their login credentials before continuing.
This ensures we have a backend client that we can use to
query the workspaces in this account before continuing with the
init process.