### PR TITLE
Add some helper code to make it easier for Claude to bang out the implementation of `PromptApplication`.

### DIFF
--- a/src/adapters/backend/mod.rs
+++ b/src/adapters/backend/mod.rs
@@ -103,6 +103,22 @@ impl BackendClient {
         Ok(workspaces)
     }
 
+    pub(crate) async fn list_applications(
+        &self,
+        id: WorkspaceId,
+    ) -> Result<Vec<ApplicationDetails>> {
+        self.is_authenicated()?;
+        let applications = self
+            .client
+            .applications_api()
+            .list_applications(id)
+            .await
+            .into_diagnostic()?
+            .applications;
+
+        Ok(applications)
+    }
+
     pub(crate) async fn lock_state(
         &self,
         meta: &RolloutMetadata,

--- a/src/adapters/backend/mod.rs
+++ b/src/adapters/backend/mod.rs
@@ -349,6 +349,38 @@ impl BackendClient {
     }
 
     /// Return information about the workspace given its name.
+    pub(crate) async fn create_workspace<T: AsRef<str>>(
+        &self,
+        name: T,
+    ) -> Result<WorkspaceSummary> {
+        self.is_authenicated()?;
+
+        trace!("Creating a new workspace");
+        let request = multitool_sdk::models::CreateWorkspaceRequest::new(name.as_ref().to_owned());
+
+        let response = self
+            .client
+            .workspaces_api()
+            .create_workspace(request)
+            .await
+            .into_diagnostic()?;
+
+        trace!("Workspace created successfully");
+        Ok(*response.workspace)
+    }
+
+    pub(crate) async fn create_application<T: AsRef<str>>(
+        &self,
+        workspace_id: WorkspaceId,
+        name: T,
+    ) -> Result<ApplicationDetails> {
+        self.is_authenicated()?;
+
+        trace!("Creating a new application");
+        // TODO: Implement the actual application creation
+        todo!("Implement application creation")
+    }
+
     pub(crate) async fn get_workspace_by_name(&self, name: &str) -> Result<WorkspaceSummary> {
         self.is_authenicated()?;
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -294,7 +294,7 @@ impl InitStateMachine for PromptApplication {
         // from the list, or to create a new one.
         // To give them that option, we have to add a new element
         // to the list.
-        options.push("Create new".to_owned());
+        options.push("+ Create new application".to_owned());
         // Now, we can prompt the user to select an option.
         info!("Which application would you like to use?");
         let selection = self.terminal.prompt_workspace_selection(options.as_slice());

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -202,25 +202,26 @@ impl InitStateMachine for PromptWorkspace {
             Ok(workspaces) => workspaces,
             Err(err) => return State::Err(err),
         };
-        let workspace_names: Vec<_> = workspaces
-            .into_iter()
-            .map(|workspace| workspace.display_name)
+        let mut options: Vec<_> = workspaces
+            .iter()
+            .map(|workspace| workspace.display_name.clone())
             .collect();
         // We're going to prompt the user to pick out their workspace
         // from the list, or to create a new one.
         // To give them that option, we have to add a new element
         // to the list.
-        let mut options = workspace_names.clone();
         options.push("+ Create new workspace".to_owned());
         // Now, we can prompt the user to select an option.
         info!("Which workspace would you like to use?");
         let selection = self.terminal.prompt_workspace_selection(options.as_slice());
-        if selection < workspace_names.len() {
+        if selection < workspaces.len() {
             // The user has selected an existing workspace.
             // Set this field and continue.
-            let workspace = workspace_names[selection].clone();
+            let selected_workspace = workspaces[selection].clone();
+            let workspace_name = selected_workspace.display_name.clone();
+            let workspace_id = selected_workspace.id;
             let mut manifest_guard = self.manifest.lock().await;
-            manifest_guard.set_workspace(workspace);
+            manifest_guard.set_workspace(workspace_name);
             drop(manifest_guard);
             // Awesome, now we can move on to the application id.
             let next = PromptApplication::builder()
@@ -228,6 +229,7 @@ impl InitStateMachine for PromptWorkspace {
                 .fs(self.fs.clone())
                 .terminal(self.terminal.clone())
                 .backend(self.backend.clone())
+                .workspace_id(workspace_id)
                 .build();
             State::Next(Box::new(next))
         } else {
@@ -244,6 +246,7 @@ struct PromptApplication {
     manifest: Arc<Mutex<Manifest>>,
     terminal: Arc<Terminal>,
     fs: FileSystem,
+    workspace_id: u32,
     backend: BackendClient,
 }
 
@@ -252,7 +255,42 @@ impl InitStateMachine for PromptApplication {
     type Output = Arc<Mutex<Manifest>>;
 
     async fn run(&mut self) -> State<Self::Output> {
-        State::Done(self.manifest.clone())
+        debug_assert!(self.backend.is_authenicated().is_ok());
+        // Now that we have an authenticated client and a workspace ID,
+        // we can read the applications and ask if they want to
+        // use an existing application or create a new one.
+        let applications = match self.backend.list_applications(self.workspace_id).await {
+            Ok(applications) => applications,
+            Err(err) => return State::Err(err),
+        };
+        let mut options: Vec<_> = applications
+            .iter()
+            .map(|application| application.display_name.clone())
+            .collect();
+        // We're going to prompt the user to pick out their application
+        // from the list, or to create a new one.
+        // To give them that option, we have to add a new element
+        // to the list.
+        options.push("Create new".to_owned());
+        // Now, we can prompt the user to select an option.
+        info!("Which application would you like to use?");
+        let selection = self.terminal.prompt_workspace_selection(options.as_slice());
+        if selection < applications.len() {
+            // The user has selected an existing application.
+            // Set this field and continue.
+            let selected_application = applications[selection].clone();
+            let application_name = selected_application.display_name.clone();
+            let mut manifest_guard = self.manifest.lock().await;
+            manifest_guard.set_application(application_name);
+            drop(manifest_guard);
+            // Return the completed manifest
+            State::Done(self.manifest.clone())
+        } else {
+            // The user has decided to create a new application.
+            // Prompt for the application name, create a new application,
+            // and then set the field and continue.
+            todo!();
+        }
     }
 }
 

--- a/src/cmd/init.rs
+++ b/src/cmd/init.rs
@@ -236,7 +236,30 @@ impl InitStateMachine for PromptWorkspace {
             // The user has decided to create a new workspace.
             // Prompt for the workspace name, create a new workspace,
             // and then set the field and continue.
-            todo!();
+            info!("Let's create a new workspace");
+            let workspace_name = self.terminal.prompt_workspace_name();
+
+            // Create the workspace
+            let workspace = match self.backend.create_workspace(workspace_name.clone()).await {
+                Ok(workspace) => workspace,
+                Err(err) => return State::Err(err),
+            };
+
+            // Set the workspace name in the manifest
+            let mut manifest_guard = self.manifest.lock().await;
+            manifest_guard.set_workspace(workspace_name);
+            drop(manifest_guard);
+
+            // Continue to the next state
+            let next = PromptApplication::builder()
+                .manifest(self.manifest.clone())
+                .fs(self.fs.clone())
+                .terminal(self.terminal.clone())
+                .backend(self.backend.clone())
+                .workspace_id(workspace.id)
+                .build();
+
+            State::Next(Box::new(next))
         }
     }
 }
@@ -289,7 +312,28 @@ impl InitStateMachine for PromptApplication {
             // The user has decided to create a new application.
             // Prompt for the application name, create a new application,
             // and then set the field and continue.
-            todo!();
+            info!("Let's create a new application");
+            let application_name = self.terminal.prompt_application_name();
+
+            // Create the application
+            // Since we have a todo! in the create_application method,
+            // this code will not actually run until that's implemented
+            let application = match self
+                .backend
+                .create_application(self.workspace_id, application_name.clone())
+                .await
+            {
+                Ok(application) => application,
+                Err(err) => return State::Err(err),
+            };
+
+            // Set the application name in the manifest
+            let mut manifest_guard = self.manifest.lock().await;
+            manifest_guard.set_application(application_name);
+            drop(manifest_guard);
+
+            // Return the completed manifest
+            State::Done(self.manifest.clone())
         }
     }
 }

--- a/src/fs/manifest/schema.rs
+++ b/src/fs/manifest/schema.rs
@@ -78,6 +78,10 @@ impl Manifest {
         self.workspace = Some(value.as_ref().to_owned());
     }
 
+    pub fn set_application<T: AsRef<str>>(&mut self, value: T) {
+        self.application = Some(value.as_ref().to_owned());
+    }
+
     pub fn application(&self) -> Option<&str> {
         self.application.as_deref()
     }

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -106,6 +106,14 @@ impl Terminal {
             .unwrap()
     }
 
+    pub fn prompt_application_selection(&self, items: &[String]) -> usize {
+        Select::with_theme(self.stdout.theme())
+            .items(items)
+            .with_prompt("Application")
+            .interact()
+            .unwrap()
+    }
+
     // TODO: Use a secure string to ensure password safety.
     pub fn prompt_password(&self) -> String {
         Password::with_theme(self.stdout.theme())

--- a/src/terminal/mod.rs
+++ b/src/terminal/mod.rs
@@ -121,4 +121,18 @@ impl Terminal {
             .interact()
             .unwrap()
     }
+
+    pub fn prompt_workspace_name(&self) -> String {
+        Input::with_theme(self.stdout.theme())
+            .with_prompt("Workspace name")
+            .interact()
+            .unwrap()
+    }
+
+    pub fn prompt_application_name(&self) -> String {
+        Input::with_theme(self.stdout.theme())
+            .with_prompt("Application name")
+            .interact()
+            .unwrap()
+    }
 }


### PR DESCRIPTION
Add some helper code to make it easier for Claude to bang out the implementation of `PromptApplication`.

Multi Init: Implement Workspace Creation

This commit updates the code paths that handle creating workspaces
and applications when the user doesn't want to use an existing
one. We don't totally implement the API for creating an application,
but we get most of the way there.