### PR TITLE
Switch shutdown order from all-at-once to depth-first.

### DIFF
--- a/src/cmd/run.rs
+++ b/src/cmd/run.rs
@@ -178,7 +178,7 @@ impl Run {
                 s.start(SubsystemBuilder::new(
                     CONTROLLER_SUBSYSTEM_NAME,
                     controller.into_subsystem(),
-                ));
+                ).detached());
             })
             .catch_signals()
             .handle_shutdown_requests(Duration::from_millis(DEFAULT_SHUTDOWN_TIMEOUT))

--- a/src/subsystems/controller/mod.rs
+++ b/src/subsystems/controller/mod.rs
@@ -79,29 +79,34 @@ impl IntoSubsystem<Report> for ControllerSubsystem {
             .build();
 
         // • Start the ingress subsystem.
-        subsys.start(SubsystemBuilder::new(
-            INGRESS_SUBSYSTEM_NAME,
-            ingress_subsystem.into_subsystem(),
-        ));
+        subsys.start(
+            SubsystemBuilder::new(INGRESS_SUBSYSTEM_NAME, ingress_subsystem.into_subsystem())
+                .detached(),
+        );
 
         // • Start the platform subsystem.
-        subsys.start(SubsystemBuilder::new(
-            PLATFORM_SUBSYSTEM_NAME,
-            platform_subsystem.into_subsystem(),
-        ));
+        subsys.start(
+            SubsystemBuilder::new(PLATFORM_SUBSYSTEM_NAME, platform_subsystem.into_subsystem())
+                .detached(),
+        );
 
         // • Start the MonitorController subsytem.
-        subsys.start(SubsystemBuilder::new(
-            MONITOR_CONTROLLER_SUBSYSTEM_NAME,
-            monitor_controller.into_subsystem(),
-        ));
+        subsys.start(
+            SubsystemBuilder::new(
+                MONITOR_CONTROLLER_SUBSYSTEM_NAME,
+                monitor_controller.into_subsystem(),
+            )
+            .detached(),
+        );
 
         // • Start the relay subsystem.
-        subsys.start(SubsystemBuilder::new(
-            RELAY_SUBSYSTEM_NAME,
-            relay_subsystem.into_subsystem(),
-        ));
+        subsys.start(
+            SubsystemBuilder::new(RELAY_SUBSYSTEM_NAME, relay_subsystem.into_subsystem())
+                .detached(),
+        );
 
+        subsys.on_shutdown_requested().await;
+        subsys.request_local_shutdown();
         subsys.wait_for_children().await;
         Ok(())
     }

--- a/src/subsystems/controller/monitor.rs
+++ b/src/subsystems/controller/monitor.rs
@@ -136,10 +136,10 @@ impl IntoSubsystem<Report> for MonitorController<StatusCode> {
         let mut handle = monitor_subsystem.handle();
 
         // • Launch the subsystem.
-        subsys.start(SubsystemBuilder::new(
-            MONITOR_SUBSYSTEM_NAME,
-            monitor_subsystem.into_subsystem(),
-        ));
+        subsys.start(
+            SubsystemBuilder::new(MONITOR_SUBSYSTEM_NAME, monitor_subsystem.into_subsystem())
+                .detached(),
+        );
 
         // Now, we can periodically poll the monitor for
         // new data.
@@ -163,6 +163,7 @@ impl IntoSubsystem<Report> for MonitorController<StatusCode> {
                     // the monitor is shut down.
                     // NB: We can't implement the shutdown trait because
                     // self has been partially moved.
+                    subsys.request_local_shutdown();
                     subsys.wait_for_children().await;
                     return Ok(());
                 }

--- a/src/subsystems/ingress/mod.rs
+++ b/src/subsystems/ingress/mod.rs
@@ -88,6 +88,8 @@ impl IntoSubsystem<Report> for IngressSubsystem {
         loop {
             select! {
                 _ = subsys.on_shutdown_requested() => {
+                    subsys.request_local_shutdown();
+                    subsys.wait_for_children().await;
                     return self.shutdown().await;
                 }
                 // Shutdown signal from one of the handles. Since this thread has exclusive

--- a/src/subsystems/monitor/mod.rs
+++ b/src/subsystems/monitor/mod.rs
@@ -81,6 +81,8 @@ impl IntoSubsystem<Report> for MonitorSubsystem<StatusCode> {
         loop {
             select! {
                 _ = subsys.on_shutdown_requested() => {
+                    subsys.request_local_shutdown();
+                    subsys.wait_for_children().await;
                     return self.shutdown().await;
                 }
                 _ = self.shutdown.recv() => {

--- a/src/subsystems/platform/mod.rs
+++ b/src/subsystems/platform/mod.rs
@@ -97,6 +97,8 @@ impl IntoSubsystem<Report> for PlatformSubsystem {
             select! {
                 // Shutdown comes first so it has high priority.
                 _ = subsys.on_shutdown_requested() => {
+                    subsys.request_local_shutdown();
+                    subsys.wait_for_children().await;
                     return self.shutdown().await;
                 }
                 // Shutdown signal from one of the handles. Since this thread has exclusive

--- a/src/subsystems/relay/lock_mgmt.rs
+++ b/src/subsystems/relay/lock_mgmt.rs
@@ -79,6 +79,8 @@ impl IntoSubsystem<Report> for LockManager {
                     }
                  }
                 _ = subsys.on_shutdown_requested() => {
+                    subsys.request_local_shutdown();
+                    subsys.wait_for_children().await;
                     // Release the lock.
                     return self.shutdown().await;
                 }

--- a/src/subsystems/relay/mod.rs
+++ b/src/subsystems/relay/mod.rs
@@ -92,16 +92,14 @@ impl IntoSubsystem<Report> for RelaySubsystem<StatusCode> {
         // Kick off a task to poll the backend for new states.
         let mut poller = self.new_poller();
         let mut state_stream = poller.take_stream()?;
-        subsys.start(SubsystemBuilder::new(
-            "StatePoller",
-            poller.into_subsystem(),
-        ));
+        subsys.start(SubsystemBuilder::new("StatePoller", poller.into_subsystem()).detached());
 
         let mut observations = self.observations;
         loop {
             select! {
                 // Besides that, we can just hang out.
                 _ = subsys.on_shutdown_requested() => {
+                    subsys.request_local_shutdown();
                     subsys.wait_for_children().await;
                     return Ok(());
                 }
@@ -133,7 +131,7 @@ impl IntoSubsystem<Report> for RelaySubsystem<StatusCode> {
                         subsys.start(SubsystemBuilder::new(
                             format!("LockManager {}", state_id),
                             lock_manager.into_subsystem(),
-                        ));
+                        ).detached());
                         // Now that we have the lock managed, we
                         // need to tell the Platform/Ingress
                         // to effect the state.

--- a/src/subsystems/relay/poll_state.rs
+++ b/src/subsystems/relay/poll_state.rs
@@ -70,6 +70,8 @@ impl IntoSubsystem<Report> for StatePoller {
         loop {
             select! {
                 _ = subsys.on_shutdown_requested() => {
+                    subsys.request_local_shutdown();
+                    subsys.wait_for_children().await;
                     return self.shutdown().await
                 }
                 _ = self.timer.tick() => {


### PR DESCRIPTION
This commit changes the shutdown order of the subsystems.
Previously, when Ctrl-C was received, all subsystems would
simultaniously receive the shutdown signal. Now, all parent
subsystems receive the shutdown signal first, then propagate
the signal to their children. They also wait for their children
to shutdown before shutting down themselves.

This will allow us to control the order in which shutdown occurs.
For example, we can wait for channels to drain before closing them,
or differentiate between Ctrl-C shutdowns and error shutdowns.